### PR TITLE
Fix nondeterministic test failures in tales.rst

### DIFF
--- a/docs/tales.rst
+++ b/docs/tales.rst
@@ -199,6 +199,10 @@ We are now updating our original template to provide the message text:
   ... </html>
   ... ''')
 
+Let's make sure the template will be reloaded from disk
+
+  >>> FrontPage.index.__func__._v_last_read = 0
+
 Now we should get two message boxes with different text:
 
   >>> print(view().strip())
@@ -260,6 +264,7 @@ well:
   ...   </body>
   ... </html>
   ... ''')
+  >>> FrontPage.index.__func__._v_last_read = 0
 
 Now we should get two message boxes with different text and types:
 


### PR DESCRIPTION
The test does the following:

  - write a page template to a file on disk in a temporary directory
  - create a view class with a ViewPageTemplateFile() attribute
  - rewrite the same page template file
  - expect the ViewPageTemplateFile() to notice the changed mtime and reload the template
  - (and it does the rewrite + expect a second time later)

This can easily fail when the writes happen fast enough that the temporary file gets the same mtime value on disk, depending on filesystem timestamp granularity.

To avoid the failure we can trick the ViewPageTemplateFile into thinking that the template was never loaded so it will definitely be reloaded.

I don't particularly like this solution: it depends on the implementation details of SimpleViewClass, ViewPageTemplateFile and BoundPageTemplate too much.

Closes #12.